### PR TITLE
ugettext_lazy has been removed in Django 4.0 just I replaced ugettext_lazy with  gettext_lazy :

### DIFF
--- a/phone_login/models.py
+++ b/phone_login/models.py
@@ -9,7 +9,7 @@ from django.contrib.auth.base_user import BaseUserManager
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from phonenumber_field.modelfields import PhoneNumberField
 from sendsms.message import SmsMessage
 


### PR DESCRIPTION
please accept my little bit changes PR 
Thanks

